### PR TITLE
fix start block / to block assignment to filter

### DIFF
--- a/lib/requestFactory/index.js
+++ b/lib/requestFactory/index.js
@@ -75,9 +75,9 @@ class RequestFactory {
 
   async getRequestCreatedLogs(filter = {}, fromBlock = 1, toBlock = "latest") {
     const event = this.instance.RequestCreated(
-      filter,
-      { fromBlock, toBlock }
-    )
+      Object.assign(filter, { fromBlock, toBlock })
+    );
+
     return new Promise((resolve, reject) => {
       event.get((err, logs) => {
         if (!err) {
@@ -89,12 +89,13 @@ class RequestFactory {
 
   async watchRequestCreatedLogs(filter = {}, fromBlock = 1, callback) {
     const event = this.instance.RequestCreated(
-      filter,
-      { fromBlock, toBlock: 'latest' }
+      Object.assign(filter, { fromBlock, toBlock: 'latest' })
     );
+
     event.watch(function(e,r){
       callback(e,r);
     });
+    
     return event;
   }
 


### PR DESCRIPTION
The filter object was not being assigned the `fromBlock` or `toBlock` fields.