### PR TITLE
Add fetching total amount of transferred ETH

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,4 @@ lib/assets/tester.json
 lib/assets/development.json
 lib/build/contracts
 script.js
-build/
 build

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ lib/assets/tester.json
 lib/assets/development.json
 lib/build/contracts
 script.js
+build/
+build

--- a/index.js
+++ b/index.js
@@ -43,27 +43,29 @@ module.exports = (web3, assetJSON) => {
     return new RequestFactory(contracts.requestFactory, web3)
   };
 
+  const scheduler = async () => {
+    let contracts;
+    if (!assetJSON) {
+      const chainName = await util.getChainName()
+      contracts = require(`./lib/assets/${chainName}.json`)
+    } else {
+      contracts = assetJSON;
+    }
+    return new Scheduler(
+      contracts.blockScheduler,
+      contracts.timestampScheduler,
+      web3
+    )
+  };
+
   return {
     Constants,
     requestFactory,
-    scheduler: async () => {
-      let contracts;
-      if (!assetJSON) {
-        const chainName = await util.getChainName()
-        contracts = require(`./lib/assets/${chainName}.json`)
-      } else {
-        contracts = assetJSON;
-      }
-      return new Scheduler(
-        contracts.blockScheduler,
-        contracts.timestampScheduler,
-        web3
-      )
-    },
+    scheduler,
     transactionRequest: address => new TxRequest(address, web3),
     Util: util,
     RequestData,
-    Analytics: new Analytics(requestFactory, web3),
+    Analytics: new Analytics(web3, scheduler, requestFactory),
     version,
     contracts
   }

--- a/index.js
+++ b/index.js
@@ -63,7 +63,7 @@ module.exports = (web3, assetJSON) => {
     transactionRequest: address => new TxRequest(address, web3),
     Util: util,
     RequestData,
-    Analytics: new Analytics(requestFactory),
+    Analytics: new Analytics(requestFactory, web3),
     version,
     contracts
   }

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 
 const Constants = require("./lib/constants")
 const RequestFactory = require("./lib/requestFactory")
+const Analytics = require("./lib/analytics")
 const Scheduler = require("./lib/scheduling")
 const TxRequest = require("./lib/txRequest")
 const Util = require("./lib/util")
@@ -30,18 +31,21 @@ module.exports = (web3, assetJSON) => {
   }
 
   const util = Util(web3)
+
+  const requestFactory = async () => {
+    let contracts;
+    if (!assetJSON) {
+      const chainName = await util.getChainName()
+      contracts = require(`./lib/assets/${chainName}.json`)
+    } else {
+      contracts = assetJSON;
+    }
+    return new RequestFactory(contracts.requestFactory, web3)
+  };
+
   return {
     Constants,
-    requestFactory: async () => {
-      let contracts;
-      if (!assetJSON) {
-        const chainName = await util.getChainName()
-        contracts = require(`./lib/assets/${chainName}.json`)
-      } else {
-        contracts = assetJSON;
-      }
-      return new RequestFactory(contracts.requestFactory, web3)
-    },
+    requestFactory,
     scheduler: async () => {
       let contracts;
       if (!assetJSON) {
@@ -59,6 +63,7 @@ module.exports = (web3, assetJSON) => {
     transactionRequest: address => new TxRequest(address, web3),
     Util: util,
     RequestData,
+    Analytics: new Analytics(requestFactory),
     version,
     contracts
   }

--- a/lib/analytics/index.js
+++ b/lib/analytics/index.js
@@ -10,7 +10,6 @@ class Analytics {
   }
 
   async getTotalEthTransferred() {
-
     let totalEthTransferred = 0;
 
     this._scheduler = await this._scheduler();

--- a/lib/analytics/index.js
+++ b/lib/analytics/index.js
@@ -3,15 +3,47 @@ const TxRequest = require("../txRequest")
 const { BigNumber } = require("bignumber.js")
 
 class Analytics {
-  constructor(requestFactory) {
+  constructor(requestFactory, web3) {
     this._requestFactory = requestFactory;
+    this._web3 = web3;
   }
 
   async getTotalEthTransferred() {
-    const requestFactory = web3.eth.contract(Util.getABI('RequestFactory')).at(this._requestFactory.address);
-    const fromBlock = await Util.getRequestFactoryStartBlock(web3);
 
-    console.log(fromBlock)
+    let totalEthTransferred = 0;
+
+    try {
+      const baseUrl = 'http://api.etherscan.io/api?module=account&action=txlist&startblock=0&endblock=99999999&sort=asc&';
+      const timestampSchedulerUrl = baseUrl + 'address=0x09e0c54ed4cffca45d691d5eb7b976d650f5904c';
+      const blockSchedulerUrl = baseUrl + 'address=0x56efae8a6d07fb29c24e67d76f3eccac180cf527';
+  
+      const urls = [timestampSchedulerUrl, blockSchedulerUrl];
+  
+      let promises = [];
+  
+      urls.forEach(url => {
+        const resultPromise = fetch(url).then(async (resp) => {
+          const response = await resp.json();
+          const weiTransferred = response.result.reduce((acc, tx) => acc + parseInt(tx.value), 0);
+          return this._web3.fromWei(weiTransferred, 'ether');
+        });
+  
+        promises.push(resultPromise);
+      });
+  
+      const values = await Promise.all(promises);
+      totalEthTransferred = values.reduce((acc, value) => acc + parseFloat(value), 0);
+    } catch (e) {
+      console.log('Unable to connect to Etherscan. Fetching analytics natively...');
+      totalEthTransferred = this.getTotalEthTransferredNatively();
+    }
+
+    return totalEthTransferred;
+  }
+
+  async getTotalEthTransferredNatively() {
+    const requestFactory = this._web3.eth.contract(Util.getABI('RequestFactory')).at(this._requestFactory.address);
+    const fromBlock = await Util.getRequestFactoryStartBlock(this._web3);
 
     let transactions = await new Promise(resolve => {
       requestFactory
@@ -27,13 +59,13 @@ class Analytics {
     });
 
     transactions = await Promise.all(transactions.map(async (tx) => {
-      const request = new TxRequest(tx.address, web3);
+      const request = new TxRequest(tx.address, this._web3);
       await request.fillData();
       return request;
     }));
 
     const weiTransferred = transactions.reduce((acc, tx) => acc.plus(tx.callValue), new BigNumber(0));
-    const ethTransferred = web3.fromWei(weiTransferred, 'ether').toNumber();
+    const ethTransferred = this._web3.fromWei(weiTransferred, 'ether').toNumber();
 
     return ethTransferred;
   }

--- a/lib/analytics/index.js
+++ b/lib/analytics/index.js
@@ -1,0 +1,42 @@
+const Util = require("../util")()
+const TxRequest = require("../txRequest")
+const { BigNumber } = require("bignumber.js")
+
+class Analytics {
+  constructor(requestFactory) {
+    this._requestFactory = requestFactory;
+  }
+
+  async getTotalEthTransferred() {
+    const requestFactory = web3.eth.contract(Util.getABI('RequestFactory')).at(this._requestFactory.address);
+    const fromBlock = await Util.getRequestFactoryStartBlock(web3);
+
+    console.log(fromBlock)
+
+    let transactions = await new Promise(resolve => {
+      requestFactory
+        .RequestCreated({}, { fromBlock, toBlock: 'latest' })
+        .get((error, events) => {
+          resolve(
+            events.map(log => ({
+              address: log.args.request,
+              params: log.args.params
+            }))
+          );
+        });
+    });
+
+    transactions = await Promise.all(transactions.map(async (tx) => {
+      const request = new TxRequest(tx.address, web3);
+      await request.fillData();
+      return request;
+    }));
+
+    const weiTransferred = transactions.reduce((acc, tx) => acc.plus(tx.callValue), new BigNumber(0));
+    const ethTransferred = web3.fromWei(weiTransferred, 'ether').toNumber();
+
+    return ethTransferred;
+  }
+}
+
+module.exports = Analytics;

--- a/lib/analytics/index.js
+++ b/lib/analytics/index.js
@@ -3,35 +3,46 @@ const TxRequest = require("../txRequest")
 const { BigNumber } = require("bignumber.js")
 
 class Analytics {
-  constructor(requestFactory, web3) {
-    this._requestFactory = requestFactory;
+  constructor(web3, scheduler, requestFactory) {
     this._web3 = web3;
+    this._scheduler = scheduler;
+    this._requestFactory = requestFactory;
   }
 
   async getTotalEthTransferred() {
 
     let totalEthTransferred = 0;
 
-    try {
-      const baseUrl = 'http://api.etherscan.io/api?module=account&action=txlist&startblock=0&endblock=99999999&sort=asc&';
-      const timestampSchedulerUrl = baseUrl + 'address=0x09e0c54ed4cffca45d691d5eb7b976d650f5904c';
-      const blockSchedulerUrl = baseUrl + 'address=0x56efae8a6d07fb29c24e67d76f3eccac180cf527';
-  
-      const urls = [timestampSchedulerUrl, blockSchedulerUrl];
-  
-      let promises = [];
-  
-      urls.forEach(url => {
-        const resultPromise = fetch(url).then(async (resp) => {
-          const response = await resp.json();
+    this._scheduler = await this._scheduler();
+
+    const chainName = await Util.getChainName(this._web3);
+
+    const subdomain = chainName === 'mainnet' ? 'api' : `api-${chainName}`;
+    const baseUrl = `http://${subdomain}.etherscan.io/api?module=account&action=txlist&startblock=0&endblock=99999999&sort=asc`;
+    const timestampSchedulerUrl = `${baseUrl}&address=${this._scheduler.timestampScheduler.address}`;
+    const blockSchedulerUrl = `${baseUrl}&address=${this._scheduler.blockScheduler.address}`;
+    
+    const urls = [timestampSchedulerUrl, blockSchedulerUrl];
+    
+    let promises = [];
+      
+    urls.forEach(url => {
+      const resultPromise = fetch(url).then(async (resp) => {
+        const response = await resp.json();
+        
+        if (response.status == "1" && response.message === "OK") {
           const weiTransferred = response.result.reduce((acc, tx) => acc + parseInt(tx.value), 0);
           return this._web3.fromWei(weiTransferred, 'ether');
-        });
-  
-        promises.push(resultPromise);
+        } else {
+          throw Error(response.result);
+        }
       });
-  
-      const values = await Promise.all(promises);
+      promises.push(resultPromise);
+    });
+    
+    let values;
+    try {
+      values = await Promise.all(promises);
       totalEthTransferred = values.reduce((acc, value) => acc + parseFloat(value), 0);
     } catch (e) {
       console.log('Unable to connect to Etherscan. Fetching analytics natively...');

--- a/lib/util.js
+++ b/lib/util.js
@@ -4,6 +4,22 @@ const { BigNumber } = require("bignumber.js")
 const Constants = require("./constants.js")
 const ethUtil = require("ethereumjs-util")
 
+const NETWORK_ID = {
+  MAINNET: '1',
+  ROPSTEN: '3',
+  RINKEBY: '4',
+  KOVAN: '42',
+  DOCKER: '1001',
+  DEVELOPMENT: '1002',
+  TOBALABA: '401697'
+};
+
+const REQUEST_FACTORY_STARTBLOCKS = {
+  [NETWORK_ID.MAINNET]: 6204104,
+  [NETWORK_ID.ROPSTEN]: 2594245,
+  [NETWORK_ID.KOVAN]: 5555500
+};
+
 const calcEndowment = (callGas, callValue, gasPrice, fee, bounty) => {
   const callGasBN = new BigNumber(callGas)
   const callValueBN = new BigNumber(callValue)
@@ -35,24 +51,24 @@ const checkForUnlockedAccount = (web3) => {
 const checkNetworkID = (web3) => {
   return new Promise((resolve) => {
     web3.version.getNetwork((err, netID) => {
-      // mainnet
-      if (netID === '1') resolve(true)
-      // ropsten
-      else if (netID === '3') resolve(true)
-      // rinkeby
-      else if (netID === '4') resolve(true)
-      // kovan
-      else if (netID === '42') resolve(true)
-      // docker
-      else if (netID === '1001') resolve(true)
-      // development
-      else if (netID === '1002') resolve(true)
-      // tobalaba
-      else if (netID === '401697') resolve(true)
-      else resolve(false)
+      if (Object.values(NETWORK_ID).includes(netID)) {
+        resolve(true);
+      }
+      resolve(false)
     })
   })
 }
+
+const getRequestFactoryStartBlock = (web3) => {
+  return new Promise(resolve => {
+      web3.version.getNetwork((err, netID) => {
+      if (Object.keys(REQUEST_FACTORY_STARTBLOCKS).includes(netID)) {
+        resolve(REQUEST_FACTORY_STARTBLOCKS[netID]);
+      }
+      resolve(0);
+    });
+  });
+};
 
 const checkNotNullAddress = (address) => {
   if (address === Constants.NULL_ADDRESS) return false
@@ -137,20 +153,20 @@ const getTxRequestFromReceipt = (receipt) => {
 const getChainName = web3 => new Promise((resolve, reject) => {
   web3.version.getNetwork((err, netID) => {
     if (!err) {
-      if (netID === '1') {
+      if (netID === NETWORK_ID.MAINNET) {
         // return 'mainnet'
         resolve("mainnet");
-      } else if (netID === '3') {
+      } else if (netID === NETWORK_ID.ROPSTEN) {
         resolve("ropsten");
-      } else if (netID === '4') {
+      } else if (netID === NETWORK_ID.RINKEBY) {
         resolve("rinkeby");
-      } else if (netID === '42') {
+      } else if (netID === NETWORK_ID.KOVAN) {
         resolve("kovan");
-      } else if (netID === '1001') {
+      } else if (netID === NETWORK_ID.DOCKER) {
         resolve("docker");
-      } else if (netID === '1002') {
+      } else if (netID === NETWORK_ID.DEVELOPMENT) {
         resolve("development");
-      } else if (netID === '401697') {
+      } else if (netID === NETWORK_ID.TOBALABA) {
         resolve("tobalaba");
       } else if (netID > 1517361627) {
         resolve("tester");
@@ -193,6 +209,7 @@ module.exports = (web3) => {
       getBlockNumber,
       getChainName,
       getGasPrice,
+      getRequestFactoryStartBlock,
       getTimestamp,
       getTimestampForBlock,
       getTxRequestFromReceipt,
@@ -212,6 +229,7 @@ module.exports = (web3) => {
     getBlockNumber: () => getBlockNumber(web3),
     getChainName: () => getChainName(web3),
     getGasPrice: () => getGasPrice(web3),
+    getRequestFactoryStartBlock: () => getRequestFactoryStartBlock(web3),
     getTimestamp: () => getTimestamp(web3),
     getTimestampForBlock: blockNum => getTimestampForBlock(web3, blockNum),
     getTxRequestFromReceipt,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1873,13 +1873,12 @@
       "resolved": "https://registry.npmjs.org/eth-sig-util/-/eth-sig-util-1.4.2.tgz",
       "integrity": "sha1-jZWCAsftuq6Dlwf7pvCf8ydgYhA=",
       "requires": {
-        "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git#00ba8463a7f7a67fcad737ff9c2ebd95643427f7",
         "ethereumjs-util": "^5.1.1"
       },
       "dependencies": {
         "ethereumjs-abi": {
           "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#00ba8463a7f7a67fcad737ff9c2ebd95643427f7",
-          "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
+          "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git#00ba8463a7f7a67fcad737ff9c2ebd95643427f7",
           "requires": {
             "bn.js": "^4.10.0",
             "ethereumjs-util": "^5.0.0"
@@ -5289,6 +5288,17 @@
                 "merkle-patricia-tree": "^2.1.2",
                 "rustbn.js": "~0.1.1",
                 "safe-buffer": "^5.1.1"
+              },
+              "dependencies": {
+                "async-eventemitter": {
+                  "version": "0.2.4",
+                  "resolved": "https://registry.npmjs.org/async-eventemitter/-/async-eventemitter-0.2.4.tgz",
+                  "integrity": "sha512-pd20BwL7Yt1zwDFy+8MX8F1+WCT8aQeKj0kQnTrH9WaeRETlRamVhD0JtRPmrV4GfOJ2F9CvdQkZeZhnh2TuHw==",
+                  "dev": true,
+                  "requires": {
+                    "async": "^2.4.0"
+                  }
+                }
               }
             },
             "pify": {
@@ -11958,7 +11968,6 @@
       "integrity": "sha1-PpcwauAk+yThCj11yIQwJWIhUSA=",
       "dev": true,
       "requires": {
-        "bignumber.js": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
         "crypto-js": "^3.1.4",
         "utf8": "^2.1.1",
         "xhr2": "*",
@@ -11967,8 +11976,7 @@
       "dependencies": {
         "bignumber.js": {
           "version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
-          "from": "git+https://github.com/frozeman/bignumber.js-nolookahead.git",
-          "dev": true
+          "from": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934"
         },
         "crypto-js": {
           "version": "3.1.8",
@@ -12253,8 +12261,7 @@
       "integrity": "sha512-Cx64NgDStynKaUGDIIOfaCd0fZusL8h5avKTkdTjUu2aHhFJhZoVBGVLhoDtUaqZGWIZGcBJOoVf2JkGUOjDRQ==",
       "requires": {
         "underscore": "1.8.3",
-        "web3-core-helpers": "1.0.0-beta.35",
-        "websocket": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2"
+        "web3-core-helpers": "1.0.0-beta.35"
       },
       "dependencies": {
         "debug": {
@@ -12267,7 +12274,7 @@
         },
         "websocket": {
           "version": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
-          "from": "git://github.com/frozeman/WebSocket-Node.git#browserifyCompatible",
+          "from": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
           "requires": {
             "debug": "^2.2.0",
             "nan": "^2.3.3",


### PR DESCRIPTION
This is a more robust version of https://github.com/chronologic/eac-counter.

Works with multiple networks and has two methods:
1. Tries to fetch the values from EtherScan first
2. If EtherScan is not reachable, it falls back to a (slower) native fetching method.